### PR TITLE
Adding a temporary Code of Conduct email address.

### DIFF
--- a/org-docs/CODE-OF-CONDUCT.md
+++ b/org-docs/CODE-OF-CONDUCT.md
@@ -60,8 +60,8 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
-All complaints will be reviewed and investigated promptly and fairly.
+<mrtkcoc@microsoft.com>. All complaints will be reviewed and investigated 
+promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.


### PR DESCRIPTION
Adding mrtkcoc@microsoft.com as a temporary contact for code of conduct issues.  Issues sent to this address will be shared with the Steering Comittee.